### PR TITLE
add dev build (run with 'npm start') #25

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "gulp-concat-css": "^0.1.4",
     "opener": "^1.3.0",
     "gulp-livereload": "^2.1.0",
-    "http-server": "^0.6.1"
+    "http-server": "^0.6.1",
+    "del": "^0.1.1",
+    "portfinder": "^0.2.1",
+    "run-sequence": "^0.3.6"
   }
 }


### PR DESCRIPTION
try it out! clone it, npm install, and do `npm start`

what you should see:
- it compiles the sass and js and copies over the index.html to a /build/dev directory
- it starts a static asset server serving the /build/dev directory on an available port and opens it in the browser
- it also starts a livereload server (on the standard lr port), so if you have the lr browser extension enabled you'll get all of those benefits (eg reload css without a full page refresh)
- it's watching for changes to any of the js, scss, or index.html file and will run the above processes again as appropriate

so, the desired outcome is you just sit down and type `npm start` and open it in your text editor and start working on things
