### PR TITLE
Gulp fix

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -96,7 +96,8 @@ gulp.task('dev', function (cb) {
 })
 
 gulp.task('serve', ['dev'], function () {
-  var lr = livereload()
+  var lr = livereload
+  lr.listen()
   gulp.watch('./build/dev/*')
     .on('change', function (file) {
       console.log('build changed', file.path)


### PR DESCRIPTION
There was an issue where the gulp tasks were over writing each other, so this fix is for that and makes sure the live reload server is set up to listen.
