### PR TITLE
Map (desktop) uses home address - closes #94

### DIFF
--- a/templates/summary.html
+++ b/templates/summary.html
@@ -14,7 +14,12 @@
 
 
       <div class="row map">
-        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3154.1190903573683!2d-122.42111979999997!3d37.763805699999956!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x808f7e2300112791%3A0x4fd453f72c384031!2s83+Rondel+Pl%2C+San+Francisco%2C+CA+94103!5e0!3m2!1sen!2sus!4v1407455478427" width="100%" height="300px" frameborder="0" style="border:0"></iframe>
+        @{
+          var iFrameUrl = 'https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3154.1190903573683!2d-122.42111979999997!3d37.763805699999956!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x808f7e2300112791%3A0x4fd453f72c384031!2s'
+          + encodeURIComponent(home.address) + ',%20chattanooga,%20tn'
+          + '!5e0!3m2!1sen!2sus!4v1407455478427'
+        }
+        <iframe src="@iFrameUrl" width="100%" height="300px" frameborder="0" style="border:0"></iframe>
       </div>
       </div>
       <div class="desktop-col data">


### PR DESCRIPTION
Instead of having the iFrame map hardcoded to my old house in the mission, I pass in the address for the home in Chattanooga.

The expected behavior is to have the map show the location of the home being viewed
