### PR TITLE
Navbar bug - closes #104

### DIFF
--- a/css/bestnest.scss
+++ b/css/bestnest.scss
@@ -51,6 +51,7 @@ nav.navbar {
     width:100%;
   }
   .container * {
+    -webkit-flex-grow:1;
     flex-grow:1;
   }
   a {


### PR DESCRIPTION
On iOS devices, the navbar wasn't flexing properly because it was missing the `flex-grow` property (it requires prefixing to be `-webkit-flex-grow`

Updated, but a good reminder that emulators aren't the same thing as testing on the physical device
